### PR TITLE
Bump Onfido SDK to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4983,9 +4983,9 @@
       "dev": true
     },
     "onfido-sdk-ui": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-2.2.0.tgz",
-      "integrity": "sha512-KtlYTpSgUX3e60snv1paDkJ6S90MLcs4R0Z6UQfx2ZVY8b6WGcNSiIBY3OEziDkBaS55RLzUfCvdJX15v3Bpbw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-2.3.0.tgz",
+      "integrity": "sha512-aTM44ZuFSiL3/9d3/EPxjqq1pHB04dobda3Bi0/eqU45LIgYtuPRVthtdXbkmqlS2GxsJatQKQlGSwSlMm8SSg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "blueimp-load-image": "2.12.2",
@@ -5002,33 +5002,20 @@
         "preact": "8.2.7",
         "preact-compat": "3.16.0",
         "raven-js": "3.9.1",
-        "react": "15.4.2",
-        "react-dom": "15.4.2",
         "react-dropzone": "3.4.0",
         "react-modal-onfido": "1.5.2",
         "react-native-listener": "1.0.1",
         "react-phone-number-input": "0.15.2",
         "react-redux": "4.4.6",
-        "react-webcam-onfido": "0.1.0",
+        "react-webcam-onfido": "0.1.1",
         "redux": "3.5.2",
         "reselect": "2.5.1",
         "socket.io-client": "2.0.4",
+        "speed-measure-webpack-plugin": "1.2.2",
         "supports-webp": "1.0.3",
         "url-search-params": "0.10.0",
         "visibilityjs": "1.2.4",
         "wpt": "https://github.com/onfido/js-client-tracker/tarball/master"
-      },
-      "dependencies": {
-        "preact": {
-          "version": "8.2.7",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
-          "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
-        },
-        "react-webcam-onfido": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.0.tgz",
-          "integrity": "sha512-GMejXSylBgawAJN255KdEfIWu+WZLO77nzo6JmBzyWs/TqoVojHYopFVmPBSPKK4rqzhvxtStwOycBrdoosCmg=="
-        }
       }
     },
     "optimist": {
@@ -5746,6 +5733,11 @@
         "uniqs": "2.0.0"
       }
     },
+    "preact": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.7.tgz",
+      "integrity": "sha512-m34Ke8U32HyKRVzUOCAcaiIBLR2ye6syiuRclU5DxyixDPDFqdLbIElhERBrF6gDbPKQR+Vpv5bZ9CCbvN6pdQ=="
+    },
     "preact-compat": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.16.0.tgz",
@@ -5965,16 +5957,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "react": {
-      "version": "15.4.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
-      "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "react-day-picker": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.2.1.tgz",
@@ -6010,16 +5992,6 @@
       "integrity": "sha512-jDqAkm/hI8Tl4HcsbhkBgB6HgpJR1e+ML1SbfxaegXYiuMxEVQm0FOwEH5WxUoo6fmIG4N+H0rSm59POuZOCaA==",
       "requires": {
         "lodash": "4.17.4"
-      }
-    },
-    "react-dom": {
-      "version": "15.4.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
-      "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
       }
     },
     "react-dropzone": {
@@ -6118,6 +6090,14 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "style-builder": "1.0.13"
+      }
+    },
+    "react-webcam-onfido": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.1.tgz",
+      "integrity": "sha512-aY5a1z/jlPCECmU+qaQI+bvF5fK+gGExSxUsh0mfDegT91uVoeQ4YOpeKfcJ/JGfrb9gB/dcpm/9nUSvq089Sg==",
+      "requires": {
+        "babel-runtime": "6.26.0"
       }
     },
     "readable-stream": {
@@ -6641,6 +6621,47 @@
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
+      }
+    },
+    "speed-measure-webpack-plugin": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
+      "integrity": "sha512-OPssnUTAdOwl/ijqToLrYUi8xHxdC9SOVV9e2AxkOC02Hua7+Jkfh3tdFCZxiMbtlghHK5Eyz87kG/XNpeM77w==",
+      "requires": {
+        "chalk": "2.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "css-loader": "^0.23.1",
     "express": "^4.14.0",
-    "onfido-sdk-ui": "2.2.0",
+    "onfido-sdk-ui": "2.3.0",
     "pem": "^1.8.3",
     "style-loader": "^0.13.1",
     "unirest": "^0.5.1"


### PR DESCRIPTION
Update JS SDK Sample App to latest released version of Onfido SDK 2.3.0