### PR TITLE
Bump onfido-sdk-ui to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,59 +1048,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.23.0.tgz",
-      "integrity": "sha512-lBBHb/NFDOy1K5E/noDkgaibTtxp8F8gmAaVhhpGvOjlcBp1wzNJhWRePYKWgjJ7yFudxGi4Qbferdhm9RwzbA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.25.0.tgz",
+      "integrity": "sha512-QDVUbUuTu58xCdId0eUO4YzpvrPdoUw1ryVy/Yep9Es/HD0fiSyO1Js0eQVkV/EdXtyo2pomc1Bpy7dbn2EJ2w==",
       "requires": {
-        "@sentry/core": "5.23.0",
-        "@sentry/types": "5.23.0",
-        "@sentry/utils": "5.23.0",
+        "@sentry/core": "5.25.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.23.0.tgz",
-      "integrity": "sha512-K8Wp/g1opaauKJh2w5Z1Vw/YdudHQgH6Ng5fBazHZxA7zB9R8EbVKDsjy8XEcyHsWB7fTSlYX/7coqmZNOADdg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.25.0.tgz",
+      "integrity": "sha512-hY6Zmo7t/RV+oZuvXHP6nyAj/QnZr2jW0e7EbL5YKMV8q0vlnjcE0LgqFXme726OJemoLk67z+sQOJic/Ztehg==",
       "requires": {
-        "@sentry/hub": "5.23.0",
-        "@sentry/minimal": "5.23.0",
-        "@sentry/types": "5.23.0",
-        "@sentry/utils": "5.23.0",
+        "@sentry/hub": "5.25.0",
+        "@sentry/minimal": "5.25.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.23.0.tgz",
-      "integrity": "sha512-P0sevLI9qAQc1J+AcHzNXwj83aG3GKiABVQJp0rgCUMtrXqLawa+j8pOHg8p7QWroHM7TKDMKeny9WemXBgzBQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.25.0.tgz",
+      "integrity": "sha512-kOlOiJV8wMX50lYpzMlOXBoH7MNG0Ho4RTusdZnXZBaASq5/ljngDJkLr6uylNjceZQP21wzipCQajsJMYB7EQ==",
       "requires": {
-        "@sentry/types": "5.23.0",
-        "@sentry/utils": "5.23.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.23.0.tgz",
-      "integrity": "sha512-/w/B7ShMVu/tLI0/A5X+w6GfdZIQdFQihWyIK1vXaYS5NS6biGI3K6DcACuMrD/h4BsqlfgdXSOHHrmCJcyCXQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.25.0.tgz",
+      "integrity": "sha512-9JFKuW7U+1vPO86k3+XRtJyooiVZsVOsFFO4GulBzepi3a0ckNyPgyjUY1saLH+cEHx18hu8fGgajvI8ANUF2g==",
       "requires": {
-        "@sentry/hub": "5.23.0",
-        "@sentry/types": "5.23.0",
+        "@sentry/hub": "5.25.0",
+        "@sentry/types": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.23.0.tgz",
-      "integrity": "sha512-PbN5MVWxrq05sZ707lc8lleV0xSsI6jWr9h9snvbAuMjcauE0lmdWmjoWKY3PAz2s1mGYFh55kIo8SmQuVwbYg=="
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.25.0.tgz",
+      "integrity": "sha512-8M4PREbcar+15wrtEqcwfcU33SS+2wBSIOd/NrJPXJPTYxi49VypCN1mZBDyWkaK+I+AuQwI3XlRPCfsId3D1A=="
     },
     "@sentry/utils": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.23.0.tgz",
-      "integrity": "sha512-D5gQDM0wEjKxhE+YNvCuCHo/6JuaORF2/3aOhoJBR+dy9EACRspg7kp3+9KF44xd2HVEXkSVCJkv8/+sHePYRQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.25.0.tgz",
+      "integrity": "sha512-Hz5spdIkMSRH5NR1YFOp5qbsY5Ud2lKhEQWlqxcVThMG5YNUc10aYv5ijL19v0YkrC2rqPjCRm7GrVtzOc7bXQ==",
       "requires": {
-        "@sentry/types": "5.23.0",
+        "@sentry/types": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
@@ -5114,9 +5114,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -5342,9 +5342,9 @@
       }
     },
     "onfido-sdk-ui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-6.0.0.tgz",
-      "integrity": "sha512-IpqeTgPXJg0Gvo826jcRiD3K0EHOriEFFFn5R32QOAGPqCQQGY/rATV57Q+VPQQL/2TZn751fq51N81GuQ5C3A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-6.0.1.tgz",
+      "integrity": "sha512-MqYzSirlwBtDIfmgws7wkwJo3bIJE4jrpyT3y3Mb9Xp82LJTE5/ezwsPWxEQlj0c9NH5o1EuUbEwcm4ZLpyU6w==",
       "requires": {
         "@babel/runtime-corejs3": "^7.8.7",
         "@sentry/browser": "^5.14.2",
@@ -6395,11 +6395,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
@@ -6723,13 +6723,20 @@
       }
     },
     "socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+      "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
       "requires": {
-        "component-emitter": "1.2.1",
+        "component-emitter": "~1.3.0",
         "debug": "~3.1.0",
         "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        }
       }
     },
     "sockjs": {
@@ -7015,28 +7022,28 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
+            "is-callable": "^1.2.2",
             "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
         },
         "is-callable": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
-          "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg=="
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
         },
         "is-regex": {
           "version": "1.1.1",
@@ -7050,6 +7057,17 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
           "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+        },
+        "object.assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+          "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.4.4",
-    "onfido-sdk-ui": "^6.0.0",
+    "onfido-sdk-ui": "^6.0.1",
     "webpack-dev-server": "^3.11.0"
   }
 }


### PR DESCRIPTION
Bump `onfido-sdk-ui` to 6.0.1 with npm audit vulnerability fix