### PR TITLE
Bump version to 6.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.21.5",
-        "onfido-sdk-ui": "^6.7.0",
+        "onfido-sdk-ui": "^6.7.2",
         "prettier": "^2.1.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -15201,9 +15201,9 @@
       }
     },
     "node_modules/onfido-sdk-ui": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-6.7.0.tgz",
-      "integrity": "sha512-n+lP+0ug/cZRRRb/oWdKVa/w7+jBVU/ps3nbCD2Wv0K4XfmlJjbg5FlIj+vTlGDZ4PBWLbBm/0Dn6fBp+qbfMg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-6.7.2.tgz",
+      "integrity": "sha512-imwSEvuRlcLQ/Fr07ToDbcb9vINCrqRcKSUlp+OISerHINtbiWaRgkT1FgRAP6foK+e251Y07WQL1gs8rkMk6w==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.8.7",
         "@sentry/browser": "^5.14.2",
@@ -27817,9 +27817,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
       }
     },
@@ -34465,9 +34465,9 @@
       }
     },
     "onfido-sdk-ui": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-6.7.0.tgz",
-      "integrity": "sha512-n+lP+0ug/cZRRRb/oWdKVa/w7+jBVU/ps3nbCD2Wv0K4XfmlJjbg5FlIj+vTlGDZ4PBWLbBm/0Dn6fBp+qbfMg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/onfido-sdk-ui/-/onfido-sdk-ui-6.7.2.tgz",
+      "integrity": "sha512-imwSEvuRlcLQ/Fr07ToDbcb9vINCrqRcKSUlp+OISerHINtbiWaRgkT1FgRAP6foK+e251Y07WQL1gs8rkMk6w==",
       "requires": {
         "@babel/runtime-corejs3": "^7.8.7",
         "@sentry/browser": "^5.14.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17881,9 +17881,9 @@
       }
     },
     "node_modules/react-scripts/node_modules/ssri": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -19562,9 +19562,9 @@
       }
     },
     "node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -21902,9 +21902,9 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -36614,9 +36614,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "ssri": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-          "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+          "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
           "requires": {
             "minipass": "^3.1.1"
           }
@@ -38067,9 +38067,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
@@ -40018,9 +40018,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.5",
-    "onfido-sdk-ui": "^6.7.1",
+    "onfido-sdk-ui": "^6.7.2",
     "prettier": "^2.1.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
Bump `onfido-sdk-ui` version to 6.7.2 including npm audit fix vulnerabilities.